### PR TITLE
[Reviewer: Steve] Fix TypeError when receiving 404 for getting private IDs

### DIFF
--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -226,7 +226,7 @@ def display_user(public_id, short=False):
                 _log.error("Failed to retrieve digest for private ID %s - HTTP status code %d", private_id, response.code)
                 success = False
     else:
-        _log.error("Failed to retrieve private IDs for public ID - HTTP status code %d", public_id, response.code)
+        _log.error("Failed to retrieve private IDs for public ID %s - HTTP status code %d", public_id, response.code)
         success = False
 
     if not short:


### PR DESCRIPTION
Hi Steve,

This is a fix for [sfr485460](http://sfr/prodAsp/scripts/MSG/Issue.asp?issue_id=435682) where we got a stack trace if we tried to display a user that didn't exist.

Tested on cc4-hstead1.