### PR TITLE
[Reviewer: Steve] Fix read ifc from file

### DIFF
--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -98,9 +98,9 @@ def build_ifc(ifc_file, domain, twin_prefix):
         try:
             with open(ifc_file, 'r') as f:
                 ifc = f.read()
-                return None
         except IOError as e:
             _log.error("Failed to read %s - %s", ifc_file, e.strerror)
+            return None
     else:
         ifc=('<?xml version="1.0" ?>\n'
               '<ServiceProfile>\n'


### PR DESCRIPTION
Hi Steve,

This is a fix for [sfr486265](http://sfr/prodAsp/scripts/MSG/SFR.asp?sfr=486265). 

Testing on CC4.

Please could you review?

In testing this, I noticed that we don't perform any checking on the validity of the XML given in the file, which can cause us to dump a stack trace after creating the user. Shall I fix this as part of this SFR?